### PR TITLE
Solve depedency issues

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,12 +18,14 @@ module "404_task_definition" {
 module "404_ecs_service" {
   source = "github.com/mergermarket/tf_load_balanced_ecs_service"
 
-  name            = "${format("%s-%s-404", var.env, var.component)}"
-  container_name  = "404"
-  container_port  = "8000"
-  vpc_id          = "${var.platform_config["vpc"]}"
-  task_definition = "${module.404_task_definition.arn}"
-  desired_count   = "${var.env == "live" ? 2 : 1}"
+  name             = "${format("%s-%s-404", var.env, var.component)}"
+  container_name   = "404"
+  container_port   = "8000"
+  vpc_id           = "${var.platform_config["vpc"]}"
+  task_definition  = "${module.404_task_definition.arn}"
+  desired_count    = "${var.env == "live" ? 2 : 1}"
+  alb_listener_arn = "${module.alb.alb_listener_arn}"
+  alb_arn          = "${module.alb.alb_arn}"
 }
 
 module "alb" {

--- a/test/test_tf_backend_router.py
+++ b/test/test_tf_backend_router.py
@@ -23,7 +23,7 @@ class TestTFBackendRouter(unittest.TestCase):
 
         # Then
         assert """
-Plan: 9 to add, 0 to change, 0 to destroy.
+Plan: 10 to add, 0 to change, 0 to destroy.
         """.strip() in output
 
     def test_create_alb(self):


### PR DESCRIPTION
Pass the ALB details into the load balanced ecs service, so that they
will be fully created before the target group is associated with the
ecs service.