### PR TITLE
Pass domain name to tf_alb instead of AWS ACM ARN

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ module "alb" {
   vpc_id                   = "${var.platform_config["vpc"]}"
   subnet_ids               = ["${split(",", var.platform_config["private_subnets"])}"]
   extra_security_groups    = "${concat(list(var.platform_config["ecs_cluster.default.client_security_group"]), var.extra_security_groups)}"
-  certificate_arn          = "${var.platform_config["elb_certificates.${replace(var.dns_domain, "/\\./", "_")}"]}"
+  certificate_domain_name  = "${format("*.%s%s", var.env != "live" ? "dev." : "", var.dns_domain)}"
   default_target_group_arn = "${module.404_ecs_service.target_group_arn}"
 
   tags = {

--- a/test/test_tf_backend_router.py
+++ b/test/test_tf_backend_router.py
@@ -17,6 +17,10 @@ class TestTFBackendRouter(unittest.TestCase):
             '-var', 'team=foobar',
             '-var', 'aws_region=eu-west-1',
             '-var-file=test/platform-config/eu-west-1.json',
+            '-target=module.backend_router.module.404_container_definition',
+            '-target=module.backend_router.module.404_task_definition',
+            '-target=module.backend_router.module.404_ecs_service',
+            '-target=module.backend_router.module.alb',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
@@ -36,6 +40,7 @@ Plan: 10 to add, 0 to change, 0 to destroy.
             '-var', 'team=foobar',
             '-var', 'aws_region=eu-west-1',
             '-var-file=test/platform-config/eu-west-1.json',
+            '-target=module.backend_router.module.alb',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
@@ -74,6 +79,7 @@ Plan: 10 to add, 0 to change, 0 to destroy.
             '-var', 'team=foobar',
             '-var', 'aws_region=eu-west-1',
             '-var-file=test/platform-config/eu-west-1.json',
+            '-target=module.backend_router.module.alb',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
@@ -82,7 +88,7 @@ Plan: 10 to add, 0 to change, 0 to destroy.
         assert """
 + module.backend_router.alb.aws_alb_listener.https
     arn:                               "<computed>"
-    certificate_arn:                   "arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+    certificate_arn:                   "${module.aws_acm_certificate_arn.arn}"
     default_action.#:                  "1"
     default_action.0.target_group_arn: "${var.default_target_group_arn}"
     default_action.0.type:             "forward"
@@ -102,6 +108,7 @@ Plan: 10 to add, 0 to change, 0 to destroy.
             '-var', 'team=foobar',
             '-var', 'aws_region=eu-west-1',
             '-var-file=test/platform-config/eu-west-1.json',
+            '-target=module.backend_router.module.alb',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
@@ -144,6 +151,7 @@ Plan: 10 to add, 0 to change, 0 to destroy.
             '-var', 'team=foobar',
             '-var', 'aws_region=eu-west-1',
             '-var-file=test/platform-config/eu-west-1.json',
+            '-target=module.backend_router.module.404_task_definition',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
@@ -163,6 +171,7 @@ Plan: 10 to add, 0 to change, 0 to destroy.
             '-var', 'team=foobar',
             '-var', 'aws_region=eu-west-1',
             '-var-file=test/platform-config/eu-west-1.json',
+            '-target=module.backend_router.module.alb',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
@@ -199,6 +208,7 @@ Plan: 10 to add, 0 to change, 0 to destroy.
             '-var', 'team=foobar',
             '-var', 'aws_region=eu-west-1',
             '-var-file=test/platform-config/eu-west-1.json',
+            '-target=module.backend_router.module.404_ecs_service',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
@@ -235,6 +245,7 @@ Plan: 10 to add, 0 to change, 0 to destroy.
             '-var', 'team=foobar',
             '-var', 'aws_region=eu-west-1',
             '-var-file=test/platform-config/eu-west-1.json',
+            '-target=module.backend_router.module.404_ecs_service',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')
@@ -263,6 +274,7 @@ Plan: 10 to add, 0 to change, 0 to destroy.
             '-var', 'team=foobar',
             '-var', 'aws_region=eu-west-1',
             '-var-file=test/platform-config/eu-west-1.json',
+            '-target=module.backend_router.module.404_ecs_service',
             '-no-color',
             'test/infra'
         ]).decode('utf-8')


### PR DESCRIPTION
As `tf_alb` module can now resolve AWS ACM ARN itself, we no longer need to be passing the AWS ACM ARN - just need to pass the domain name (in proper format - depending on environment used).

Also - tweak tests to use targeted module testing to make sure we only invoke things we want to test (and not initialise data sources which will break tests).

JIRA: PLAT-1093