### PR TITLE
Add ability to build external backend routers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This module creates a Backend Router service which, in effect, is a shared ALB t
 Ideally, there should be a single Backend Router per Team (e.g. platform-backend-router).
 
 The Backend Router consists of:
-- **internal** ALB - as per Mergermarket policy - team Backend Routing ALBs should be configured as `internal` ALB - if you need to expose service externally you need to deploy a `frontend-router` and attach your service to it
+- an ALB
 - default, HTTPS Listener, with a certificate as per `dns_domain` parameter, by default diverting traffic to `404` ECS Service
 - 404 ECS Service which deploys all the required components (404 ECS Service, 404 Target Group, 404 IAM Role and Policy and) and runs a tiny binary which returns 404 to every call
 
@@ -21,6 +21,7 @@ Module Input Variables
 - `component` - (string) - **REQUIRED** - component name
 - `platform_config` - (map) - **REQUIRED** - Mergermarket Platform config dictionary (see tests for example one)
 - `dns_domain` - (string) - **REQUIRED** - domain to be used when looking up SSL Certificate
+- `alb_internal` - (bool) - If true, the ALB will be internal (default: `true`)
 
 Usage
 -----
@@ -38,6 +39,7 @@ variable "platform_config" {
       ecs_cluster.default.security_group: "sg-11111111",
       vpc: "vpc-12345678",
       private_subnets: "subnet-00000000,subnet-11111111,subnet-22222222"
+      public_subnets: "subnet-333333333,subnet-44444444,subnet-55555555"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,8 @@ module "alb" {
 
   name                     = "${format("%s-%s-router", var.env, var.component)}"
   vpc_id                   = "${var.platform_config["vpc"]}"
-  subnet_ids               = ["${split(",", var.platform_config["private_subnets"])}"]
+  subnet_ids               = ["${split(",", var.alb_internal ? var.platform_config["private_subnets"] : var.platform_config["public_subnets"])}"]
+  internal                 = "${var.alb_internal}"
   extra_security_groups    = "${concat(list(var.platform_config["ecs_cluster.default.client_security_group"]), var.extra_security_groups)}"
   certificate_domain_name  = "${format("*.%s%s", var.env != "live" ? "dev." : "", var.dns_domain)}"
   default_target_group_arn = "${module.404_ecs_service.target_group_arn}"

--- a/test/infra/main.tf
+++ b/test/infra/main.tf
@@ -11,6 +11,20 @@ module "backend_router" {
   dns_domain = "domain.com"
 }
 
+module "backend_router_external" {
+  source = "../.."
+
+  team            = "${var.team}"
+  env             = "${var.env}"
+  component       = "${var.component}"
+  platform_config = "${var.platform_config}"
+
+  alb_internal = "false"
+
+  # optional
+  dns_domain = "domain.com"
+}
+
 # configure provider to not try too hard talking to AWS API
 provider "aws" {
   skip_credentials_validation = true

--- a/test/platform-config/eu-west-1.json
+++ b/test/platform-config/eu-west-1.json
@@ -6,6 +6,7 @@
     "ecs_cluster.default.client_security_group": "sg-00000000",
     "ecs_cluster.default.security_group": "sg-11111111",
     "vpc": "vpc-12345678",
-    "private_subnets": "subnet-00000000,subnet-11111111,subnet-22222222"
+    "private_subnets": "subnet-00000000,subnet-11111111,subnet-22222222",
+    "public_subnets": "subnet-33333333,subnet-44444444,subnet-555555555"
   }
 }

--- a/test/test_tf_backend_router.py
+++ b/test/test_tf_backend_router.py
@@ -63,6 +63,13 @@ Plan: 10 to add, 0 to change, 0 to destroy.
         """.strip() in output # noqa
 
         assert """
+    subnets.#:                  "3"
+    subnets.1120168869:         "subnet-11111111"
+    subnets.155686431:          "subnet-00000000"
+    subnets.2655022443:         "subnet-22222222"
+        """.strip() in output # noqa
+
+        assert """
     tags.%:                     "3"
     tags.component:             "foobar"
     tags.environment:           "dev"
@@ -286,4 +293,43 @@ Plan: 10 to add, 0 to change, 0 to destroy.
 + module.backend_router.404_ecs_service.aws_iam_role_policy.policy
     name:        "<computed>"
     name_prefix: "dev-foobar-404
+        """.strip() in output # noqa
+
+    def test_create_external_alb(self):
+        # When
+        output = check_output([
+            'terraform',
+            'plan',
+            '-var', 'env=dev',
+            '-var', 'component=foobar',
+            '-var', 'team=foobar',
+            '-var', 'aws_region=eu-west-1',
+            '-var-file=test/platform-config/eu-west-1.json',
+            '-target=module.backend_router_external.module.alb',
+            '-no-color',
+            'test/infra'
+        ]).decode('utf-8')
+
+        # Then
+        assert """
++ module.backend_router_external.alb.aws_alb.alb
+    access_logs.#:              "1"
+    access_logs.0.enabled:      "false"
+    arn:                        "<computed>"
+    arn_suffix:                 "<computed>"
+    dns_name:                   "<computed>"
+    enable_deletion_protection: "false"
+    idle_timeout:               "60"
+    internal:                   "false"
+    ip_address_type:            "<computed>"
+    name:                       "dev-foobar-router"
+    security_groups.#:          "<computed>"
+    subnets.#:                  "3"
+        """.strip() in output # noqa
+
+        assert """
+    subnets.#:                  "3"
+    subnets.2377178398:         "subnet-555555555"
+    subnets.3586363601:         "subnet-33333333"
+    subnets.4231620278:         "subnet-44444444"
         """.strip() in output # noqa

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "platform_config" {
   default     = {}
 }
 
+variable "alb_internal" {
+  description = "If true, the LB will be internal"
+  type        = "string"
+  default     = "true"
+}
+
 # optional
 variable "extra_security_groups" {
   description = "Extra Security Groups to attach to the ALB"


### PR DESCRIPTION
We'd like to be able to build backend routers which will be frontend with external, public facing ALB.

Use case for this kind of configuration is when someone wants to deploy admin services - which are not destined for General Public, but still should be exposed publically for consumers.